### PR TITLE
Nit: Update searcher authorization rejection Error to Warn

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -192,7 +192,7 @@ func (a *API) ConnectedSearcher(w http.ResponseWriter, r *http.Request) {
 	// Check for sufficent balance
 	if balance.Cmp(minimalStake) < 0 {
 		a.Log.WithFields(logrus.Fields{"balance": balance, "required": minimalStake}).
-			Error("searcher has insufficient balance")
+			Warn("searcher has insufficient balance")
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
* Nit change: Updates the log level to Warn for when a searcher attempts a connection without sufficient balance.