### PR TITLE
Adds timestamp to searcher payload for latency tracking

### DIFF
--- a/integrationtest/searcher_test.go
+++ b/integrationtest/searcher_test.go
@@ -150,6 +150,7 @@ func TestConnectSearcher(t *testing.T) {
 		json.Unmarshal([]byte(NoTransactionBlockRaw), &block)
 		wg := sync.WaitGroup{}
 		wg.Add(1)
+		var currTime *int64
 		go func(t *testing.T) {
 			// Read from connection
 			mtype, r, err := conn.NextReader()
@@ -161,9 +162,11 @@ func TestConnectSearcher(t *testing.T) {
 			// Decode r into data
 			_ = json.NewDecoder(r).Decode(&data)
 			assert.Equal(t, data.Builder, "0xaa1488eae4b06a1fff840a2b6db167afc520758dc2c8af0dfb57037954df3431b747e2f900fe8805f05d635e9a29717b")
+			assert.GreaterOrEqual(t, data.SenderTimestamp, *currTime)
 			wg.Done()
 		}(t)
-
+		tnow := time.Now().Unix()
+		currTime = &tnow
 		service.SubmitBlock(context.TODO(), &block)
 		wg.Wait()
 	})

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -137,6 +137,7 @@ func (a *API) handleSearcherCommitment(w http.ResponseWriter, r *http.Request) {
 }
 
 // connectSearcher is the handler to connect a searcher to the builder for the websocket execution hints
+// TODO(@ckartik): Move the handling of searcher connection to service layer
 //
 // GET /ws?token=abcd where "abcd" is the authentication token of the searcher
 // The handler authenticates based on the following criteria:
@@ -267,6 +268,7 @@ func (a *API) ConnectedSearcher(w http.ResponseWriter, r *http.Request) {
 				delete(a.Worker.connectedSearchers, searcherAddressParam)
 				return
 			case data := <-searcherConsumeChannel:
+				data.SenderTimestamp = time.Now().Unix()
 				json, err := json.Marshal(data)
 				if err != nil {
 					a.Log.Error(err)

--- a/pkg/boost.go
+++ b/pkg/boost.go
@@ -29,12 +29,13 @@ type Transaction struct {
 }
 
 type Metadata struct {
-	Builder      string      `json:"builder"`
-	Number       int64       `json:"number"`
-	BlockHash    string      `json:"blockHash"`
-	Timestamp    string      `json:"timestamp"`
-	BaseFee      uint32      `json:"baseFee"`
-	Transactions Transaction `json:"transactions"`
+	Builder         string      `json:"builder"`
+	Number          int64       `json:"number"`
+	BlockHash       string      `json:"blockHash"`
+	Timestamp       string      `json:"timestamp"`
+	BaseFee         uint32      `json:"baseFee"`
+	Transactions    Transaction `json:"transactions"`
+	SenderTimestamp int64       `json:"sent_timestamp"`
 }
 
 var (


### PR DESCRIPTION
* Note: Due to clock differences between searchers and builders, this measure will better serve anomaly tracking rather than  accurate assessment of latency.