### PR TITLE
Searcher Example Improvements

### DIFF
--- a/pkg/searcher/searcher.go
+++ b/pkg/searcher/searcher.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/lthibault/log"
+
+	boost "github.com/primev/builder-boost/pkg"
 	"github.com/primev/builder-boost/pkg/utils"
 )
 
@@ -128,7 +130,12 @@ func (s *searcher) processMessages(c *websocket.Conn) error {
 		if err != nil {
 			return err
 		}
-
+		var m boost.Metadata
+		err = json.Unmarshal(message, &m)
+		if err != nil {
+			s.log.WithField("message", string(message)).Error("failed to unmarshal message")
+			continue
+		}
 		s.log.WithField("message", string(message)).Info("received message from builder")
 	}
 }


### PR DESCRIPTION
* We add an attempt to unmarshal the payload received by the searcher.
* This will be useful for future commits, where we want to use the data in the feed for monitoring, display, etc.