### PR TITLE
Sends empty array instead of null to searchers.

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -292,6 +292,9 @@ func (a *API) ConnectedSearcher(w http.ResponseWriter, r *http.Request) {
 			case data := <-searcherConsumeChannel:
 				metadata := data.InternalMetadata
 				metadata.SenderTimestamp = time.Now().Unix()
+				if _, ok := data.SearcherTxns[searcherID]; !ok {
+					data.SearcherTxns[searcherID] = []string{}
+				}
 				metadata.ClientTransactions = data.SearcherTxns[searcherID]
 				json, err := json.Marshal(metadata)
 				if err != nil {


### PR DESCRIPTION
* Ensures we don't send a null value over json