### PR TITLE
Avoids exiting searcher emulator on perceived EOF.

### DIFF
--- a/pkg/searcher/searcher.go
+++ b/pkg/searcher/searcher.go
@@ -166,7 +166,9 @@ func (s *searcher) processMessages(c *websocket.Conn) error {
 	for {
 		_, message, err := c.ReadMessage()
 		now = time.Now()
-		if err != nil {
+		if err != nil && err.(*websocket.CloseError).Code == websocket.CloseAbnormalClosure {
+			s.log.Error(err.Error())
+		} else if err != nil {
 			return err
 		}
 		var m boost.Metadata


### PR DESCRIPTION
* Sometimes, on startup the searcher can perceive a Abnormal EOF.
* We want to ignore this behaviour and continue to read unless a Close signal is sent to the Websocket.